### PR TITLE
Deleted the Privacy Policy section

### DIFF
--- a/legal/index.md
+++ b/legal/index.md
@@ -6,6 +6,4 @@ title: Legal
 ## License
 TAXII is released under a [permissive license for any commercial or non-commercial purpose](http://taxii.mitre.org/about/termsofuse.html) while [helper scripts and related tools](https://github.com/TAXIIProject) have individual licenses that typically follow [Berkeley Software Distribution](http://opensource.org/licenses/BSD-3-Clause). 
 
-## Privacy
-Use of websites and mailing lists is governed by our [privacy policy](http://taxii.mitre.org/about/privacy_policy.html)
 


### PR DESCRIPTION
The Privacy Policy section of the License page was specific to the MITRE websites and discussion lists, so I removed it from the License page.