### PR TITLE
Corrected bulleted list in the Community section

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -75,13 +75,13 @@ TAXII is designed to integrate with existing sharing agreements, including acces
 
 
 ## TAXII Community
-TAXII has been transitioned to [OASIS](https://www.oasis-open.org/committees/cti). See the [Community](http://taxiiproject.github.io/community/) page for more information. 
+TAXII has been transitioned to [OASIS](https://www.oasis-open.org/committees/cti). See the [Community](http://taxiiproject.github.io/community/) page for details. 
 
-Shortcuts
-- [OASIS Cyber Threat Intelligence (CTI) Technical Committee (TC)](https://www.oasis-open.org/committees/cti)  The TAXII Specifications are developed by the CTI TC and TAXII subcommittee.
-- [Mailing Lists](http://taxiiproject.github.io/community/#discussion-lists-amp-archives)  Stay up-to-date on development and usage.
-- [Developer Resources](http://taxiiproject.github.io/developers)  The central location for development of the specifications, tools, and documentation (including this site).
-- [STIX/TAXII Supporters](http://stixproject.github.io/supporters)  A growing list of products, services, and sharing communities using TAXII and STIX.
+Some shortcuts:  
+- [OASIS Cyber Threat Intelligence (CTI) Technical Committee (TC)](https://www.oasis-open.org/committees/cti) - TAXII is developed by the TAXII subcommittee of the CTI TC. 
+- [Mailing Lists](http://taxiiproject.github.io/community/#discussion-lists-amp-archives) - Stay up-to-date on development and usage. 
+- [Developer Resources](http://taxiiproject.github.io/developers) - The central location for development of the specifications, tools, and documentation (including this site). 
+- [STIX/TAXII Supporters](http://stixproject.github.io/supporters) - A growing list of products, services, and sharing communities using TAXII and STIX. 
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
What appears on the pushed page is single paragraph with dashes instead of bullets, even though the bulleted list looks perfect in the Preview.